### PR TITLE
fix(players.php): properly display players if rank_type >= 1

### DIFF
--- a/web/pages/players.php
+++ b/web/pages/players.php
@@ -351,7 +351,7 @@ For support and installation notes visit http://www.hlxcommunity.com
 			{
 				$minEvent = explode("-", $dates[$rank_type-1]['eventTime']);
 				$minEvent = mktime(0, 0, 0, $minEvent[1], $minEvent[2], $minEvent[0]);
-				$maxEvent = $minEvent + 86400;
+				$maxEvent = $minEvent;
 			}
 			$result = $db->query
 			("


### PR DESCRIPTION
For example, if a user wanted to view the players list of today and let's say today is 26th August, then they can only view the playerslist if they clicked on 25-08 from ranking view selection. this pr fixes it