### PR TITLE
Refactor SQL queries and error handling in PlayerRepository

### DIFF
--- a/web/classes/Repository/PlayerRepository.php
+++ b/web/classes/Repository/PlayerRepository.php
@@ -30,9 +30,7 @@
 
             $sql = "
                 SELECT
-                    UNIX_TIMESTAMP(eventTime)
-                AS
-                    ts, skill, skill_change
+                    UNIX_TIMESTAMP(eventTime) AS ts, skill, skill_change
                 FROM
                     hlstats_Players_History
                 WHERE
@@ -58,19 +56,14 @@
 		public function getPlayerSuggestions(string $game, string $search, int $limit = 30) : ?array
 		{
 			$limit = max(1, $limit);
+
 			$sql = "
-				SELECT DISTINCT
-					hlstats_PlayerNames.name 
-				FROM 
-					hlstats_PlayerNames 
-				INNER JOIN 
-					hlstats_Players 
-				ON 
-					hlstats_PlayerNames.playerId = hlstats_Players.playerId 
-				WHERE 
-					game = :game
-				AND 
-					name LIKE :search
+				SELECT DISTINCT hlstats_PlayerNames.name 
+				FROM hlstats_PlayerNames 
+				INNER JOIN hlstats_Players 
+					ON hlstats_PlayerNames.playerId = hlstats_Players.playerId 
+				WHERE game = :game
+				AND name LIKE :search
 				LIMIT :limit
 			";
 
@@ -83,7 +76,7 @@
                 $stmt->execute();
 
                 return $stmt->fetchAll(PDO::FETCH_COLUMN);
-			} catch (\PDOException $e) {
+			} catch (PDOException $e) {
 				$this->logger->error('PDO Exception in getPlayerSuggestions: ' . $e->getMessage());
 				return null;
 			}
@@ -93,18 +86,14 @@
         {
             $allowedRankingType = $this->optionService->getRankingTypeChoices();
             if (empty($allowedRankingType)) {
-                $allowedRankingType = ['kills', 'skill']; // default params
+                $allowedRankingType = ['kills', 'skill'];
             }
 
             if (!in_array($rankingType, $allowedRankingType, true)) {
                 return null;
             }
 
-            $tempDeaths = $playerDeaths;
-            if ($tempDeaths == 0) {
-                $tempDeaths = 1;
-            }
-
+            $tempDeaths = $playerDeaths ?: 1;
             $kpd = $playerKills / $tempDeaths;
 
             $sql = "
@@ -119,9 +108,9 @@
                 AND 
                     kills >= 1
                 AND (
-                    {$rankingType} > :points
+                    {$rankingType} > :points1
                     OR (
-                        {$rankingType} = :points
+                        {$rankingType} = :points2
                         AND (kills / IF(deaths = 0, 1, deaths) > :kpd)
                     )
                 )
@@ -131,17 +120,20 @@
                 $stmt = $this->pdo->prepare($sql);
 
                 $stmt->execute([
-                    'game'  => $game,
-                    'points' => $playerPoints,
-                    'kpd'   => $kpd,
+                    ':game'    => $game,
+                    ':points1' => $playerPoints,
+                    ':points2' => $playerPoints,
+                    ':kpd'     => $kpd,
                 ]);
 
                 $count = $stmt->fetchColumn();
+
                 if ($count === false) {
                     return null;
                 }
 
                 return (int)$count;
+
             } catch (PDOException $e) {
                 $this->logger->error("Failed to get player rank: " . $e->getMessage());
                 return null;


### PR DESCRIPTION
                            Fix: **Player rank returns "Unknown" due to SQLSTATE[HY093] Issue**

The web panel was showing "Unknown" for player rank. Logs showed:

Failed to get player rank: SQLSTATE[HY093]: Invalid parameter number
Root Cause

The issue was caused by a PDO parameter mismatch in [PlayerRepository.php](https://github.com/A1mDev/hlstatsx-community-edition/blob/master/web/classes/Repository/PlayerRepository.php):

The SQL query reused the same named parameter :points multiple times
PDO does not allow reusing identical named placeholders in some configurations
This resulted in HY093 Invalid parameter number
Fix
Replaced duplicate :points placeholders with :points1 and :points2
Updated $stmt->execute() to bind both parameters separately
Ensured all named parameters correctly match SQL placeholders
Changes
**classes/Repository/PlayerRepository.php**
Fixed **getPlayerRank()** query parameter binding
Result
Player rank now calculates correctly
No more SQLSTATE HY093 errors
Web panel now displays correct rank instead of "Unknown"
